### PR TITLE
Projects & Configuration minor fixes issue#279

### DIFF
--- a/app/modules/project/components/config-section.jsx
+++ b/app/modules/project/components/config-section.jsx
@@ -91,7 +91,7 @@ class ConfigSectionComponent extends React.PureComponent {
 
   constructor(...args) {
     super(...args);
-    this.state = {};
+    this.state = { nameValid: true };
   }
 
   generateIndexedSchema() {
@@ -175,7 +175,8 @@ class ConfigSectionComponent extends React.PureComponent {
     if (this.props.type === SECTION_USER_ENV) {
       name = SECTION_USER_ENV + name;
     }
-    this.props.onRename(name, this.props.id);
+    const nameValid = this.props.onRename(name, this.props.id);
+    this.setState({ nameValid });
   };
 
   handleRemoveOptionClick = e => {
@@ -345,6 +346,7 @@ class ConfigSectionComponent extends React.PureComponent {
     return (
       <Select
         className="select-add-new-option"
+        disabled={!this.state.nameValid}
         dropdownClassName="dropdown-add-new-option"
         showSearch
         style={{ width: '100%' }}
@@ -392,6 +394,7 @@ class ConfigSectionComponent extends React.PureComponent {
         {this.props.type === SECTION_USER_ENV && (
           <Tooltip title="Default configuration for building, uploading, debugging, etc">
             <Button
+              disabled={!this.state.nameValid}
               icon="environment"
               size="small"
               onClick={this.handleToggleMakeDefaultClick}
@@ -434,7 +437,12 @@ class ConfigSectionComponent extends React.PureComponent {
         >
           {this.props.type !== SECTION_PLATFORMIO &&
             this.props.type !== SECTION_GLOBAL_ENV && (
-              <Form.Item key={SECTION_NAME_KEY} label="Name" {...itemLayout}>
+              <Form.Item
+                key={SECTION_NAME_KEY}
+                label="Name"
+                {...itemLayout}
+                validateStatus={this.state.nameValid ? 'success' : 'error'}
+              >
                 <Input
                   addonBefore={
                     this.props.type === SECTION_USER_ENV ? SECTION_USER_ENV : undefined

--- a/app/modules/project/components/option-autocomplete.jsx
+++ b/app/modules/project/components/option-autocomplete.jsx
@@ -183,7 +183,8 @@ export class OptionAutocomplete extends React.PureComponent {
   handleFilter = (inputValue, option) =>
     this.props.remoteFilter ||
     this.props.multiple ||
-    option.props.value.toLowerCase().includes(inputValue.toLowerCase());
+    option.props.value.toLowerCase().includes(inputValue.toLowerCase()) ||
+    option.props.children.toLowerCase().includes(inputValue.toLowerCase());
 
   handleTagClose = value => {
     this.setState({

--- a/app/modules/project/containers/board-autocomplete.jsx
+++ b/app/modules/project/containers/board-autocomplete.jsx
@@ -38,7 +38,7 @@ function mapStateToProps(state, ownProps) {
             frameworks.some(framework => board.frameworks.includes(framework)))
       )
       .map(board => ({
-        name: board.name,
+        name: `${board.name} (${board.id})`,
         value: board.id
       }));
   }

--- a/app/modules/project/containers/config.jsx
+++ b/app/modules/project/containers/config.jsx
@@ -498,7 +498,13 @@ class ProjectConfig extends React.PureComponent {
   };
 
   handleSectionRename = (name, tabId) => {
+    // Prevent duplicate names
+    const existingSection = this.state.config.find(s => s.section === name);
+    if (existingSection) {
+      return false;
+    }
     this.renameSection(tabId, name);
+    return true;
   };
 
   handleSectionRemove = (_name, tabId) => {

--- a/app/modules/project/containers/framework-autocomplete.jsx
+++ b/app/modules/project/containers/framework-autocomplete.jsx
@@ -36,7 +36,7 @@ function mapStateToProps(state, ownProps) {
           framework.platforms.includes(platform)
       );
       items = items.map(framework => ({
-        name: framework.title,
+        name: `${framework.title} (${framework.name})`,
         value: framework.name
       }));
     }

--- a/app/modules/project/containers/list.jsx
+++ b/app/modules/project/containers/list.jsx
@@ -95,8 +95,14 @@ class ProjectsListComponent extends React.PureComponent {
     }
   };
 
-  handleSearch = e => {
-    this.props.setFilter(e.target.value);
+  handleFilterChange = e => {
+    this.setState({
+      filterValue: e.target.value
+    });
+  };
+
+  handleSearch = () => {
+    this.props.setFilter(this.state.filterValue);
   };
 
   handleBoardClick = name => {
@@ -253,11 +259,12 @@ class ProjectsListComponent extends React.PureComponent {
             <div className="block">
               <Input.Search
                 allowClear
+                autoFocus
                 defaultValue={this.props.filterValue}
                 enterButton
                 placeholder="Search projects"
-                onChange={this.handleSearch}
-                ref={$el => ($el ? $el.focus() : null)}
+                onChange={this.handleFilterChange}
+                onSearch={this.handleSearch}
                 size="large"
                 style={{ width: '100%' }}
               />

--- a/app/modules/project/sagas.jsx
+++ b/app/modules/project/sagas.jsx
@@ -45,6 +45,7 @@ import {
   updateEntity,
   updateStorageItem
 } from '../../store/actions';
+import { getSessionId, goTo } from '@core/helpers';
 import { selectEntity, selectStorageItem } from '../../store/selectors';
 
 import { ConfigFileModifiedError } from '@project/errors';
@@ -53,7 +54,7 @@ import React from 'react';
 import ReactGA from 'react-ga';
 import { apiFetchData } from '../../store/api';
 import { ensureUserConsent } from '@core/sagas';
-import { getSessionId } from '@core/helpers';
+
 import jsonrpc from 'jsonrpc-lite';
 
 const RECENT_PROJECTS_STORAGE_KEY = 'recentProjects';
@@ -385,6 +386,10 @@ function* watchLoadProjectConfig() {
       yield put(updateEntity(PROJECT_CONFIG_KEY, { config, mtime }));
     } catch (e) {
       yield put(notifyError('Could not load project config', e));
+      const state = yield select();
+      if (state.router) {
+        yield call(goTo, state.router.history, '/projects', undefined, true);
+      }
     }
   });
 }


### PR DESCRIPTION
- Added validation of section name to be unique.
- Added redirection to the list of projects in case of config load error;
- Display also framework name after the title in the autocompleter;
- Display also board id after the name in the autocompleter;
- Fixed project list filter to be run on enter;
- Fixed filter in the autocompleter to search also by content besides value.

// Issue #279