### PR TITLE
Use secure websocket if protocol used is 'https'

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -25,6 +25,6 @@ if (pathname[pathname.length - 1] !== '/') {
 }
 let wsrpc = `ws://127.0.0.1:8008${pathname}wsrpc`;
 if (process.env.NODE_ENV === 'production' && window.location && window.location.host) {
-  wsrpc = `ws://${window.location.host}${pathname}wsrpc`;
+  wsrpc = `${window.location.protocol === 'https:' ? 'wss:' : 'ws:'}//${window.location.host}${pathname}wsrpc`;
 }
 export const BACKEND_ENDPOINT = wsrpc;

--- a/app/config.js
+++ b/app/config.js
@@ -25,6 +25,8 @@ if (pathname[pathname.length - 1] !== '/') {
 }
 let wsrpc = `ws://127.0.0.1:8008${pathname}wsrpc`;
 if (process.env.NODE_ENV === 'production' && window.location && window.location.host) {
-  wsrpc = `${window.location.protocol === 'https:' ? 'wss:' : 'ws:'}//${window.location.host}${pathname}wsrpc`;
+  wsrpc = `${window.location.protocol === 'https:' ? 'wss:' : 'ws:'}//${
+    window.location.host
+  }${pathname}wsrpc`;
 }
 export const BACKEND_ENDPOINT = wsrpc;


### PR DESCRIPTION
Required when running platformio-vscode-ide on secured remote hosted code-server.
Part of changes required in getting the plugin to play nice in dockerized code-server environments.