### PR TITLE
Use backend system to determine path separator

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -14,8 +14,22 @@
  * limitations under the License.
  */
 
-export const IS_WINDOWS =
-  navigator && navigator.platform && navigator.platform.startsWith('Win');
+import { select, takeLatest } from 'redux-saga/effects';
+import { STORE_READY } from './store/actions';
+import { selectStorage } from './store/selectors';
+
+export function* watchLoadIsWindows() {
+  yield takeLatest(STORE_READY, function* () {
+    const storage = yield select(selectStorage);
+    if (!storage.coreSystype) {
+      return;
+    }
+    IS_WINDOWS = storage.coreSystype.indexOf('windows') > -1;
+  });
+};
+
+export let IS_WINDOWS;
+
 export const INPUT_FILTER_DELAY = 300; // ms, dalay before filtering projects, libs, platorms
 export const PLATFORMIO_API_ENDPOINT = 'https://api.platformio.org';
 

--- a/app/store/sagas.js
+++ b/app/store/sagas.js
@@ -20,7 +20,7 @@ import * as actions from './actions';
 
 import { all, call, put, select, takeLatest } from 'redux-saga/effects';
 
-import { INPUT_FILTER_DELAY } from '../config';
+import { INPUT_FILTER_DELAY, watchLoadIsWindows } from '../config';
 import accountSagas from '../modules/account/sagas';
 import { asyncDelay } from '../modules/core/helpers';
 import { backendFetchData } from './backend';
@@ -106,6 +106,7 @@ export default function* root() {
       ...projectSagas,
       ...platformSagas,
       ...inspectSagas,
+      watchLoadIsWindows,
     ].map((s) => s())
   );
 }


### PR DESCRIPTION
Here is a sample PR which allows the frontend to use the backend PIO's system type to determine if it's running in Windows or not. This affects the type of path separator that is used.

In a setup where there is a difference between the frontend system and backend (for example, Windows 11 client, WSL2 backend, or VS Code Remote), it doesn't make sense to detect the OS on the frontend, and today you are unable to create projects and navigate correctly because of this.

Caveats:
- I've done testing on Win11 + WSL2, Win11 local. I don't have a Linux system with a desktop however but have simulated it to ensure the values loaded correctly
- I'm not great at React, and never touched Redux before, so I consider this a working example, but I can't say if it's a good contribution in the current state. 
- It assumes a pretty happy path; I don't know enough about the application to know if there are situations where the app state hasn't loaded but the user is able to perform other actions (it seems like a very early bootstrap step)